### PR TITLE
[semver-minor]: Add abortOnError feature, that rejects all remaining …

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,15 @@ API
 ```js
 var promiseLimit = require('promise-limit')
 
-promiseLimit(concurrency?: Number) -> limit
+promiseLimit(concurrency?: Number, options?: Object) -> limit
 ```
 
 Returns a function that can be used to wrap promise returning functions, limiting them to `concurrency` outstanding calls.
 
 - `concurrency` the concurrency, i.e. 1 will limit calls to one at a time, effectively in sequence or serial. 2 will allow two at a time, etc. 0 or `undefined` specify no limit, and all calls will be run in parallel.
+
+- `options` are the options for the limiter, which are:
+  + `abortOnError`: (default `false`) Whether to dequeue and reject all remaining jobs in the queue with the caught error if a job rejects
 
 ```js
 limit(fn: () => Promise<T>) => Promise<T>


### PR DESCRIPTION
…jobs in queue with caught error if a job rejects. This feature is disabled by default, so it does not cause breaking changes.

This feature is useful because say I have the following code:

```js
import promiseLimit from 'promise-limit'

const limiter = promiseLimit(10)

async function processProducts (products) {
  // Assume that products is a large array of products that I want to process
  await Promise.all(
    products.map(
      (product) => limiter(
        () => {
          console.log(`Processing ${product.sku}`)
          // Calls an API that updates the product information
          return processProduct(product)
        }
      )
    )
  )
}
```

If one of the products failed to process, `Promise.all` will reject, but the products will continue processing. This is bad if I have lots of products that I want to process, I want the limiter to stop processing the rest of the products on rejection, so it doesn't waste any more resources (or cause unexpected side effects).

This is how it works:

```js
                          // Run the numbers one at a time
const limiter = promiseLimit(1, {abortOnError: true})
const numbers = [0, 1, 2, 3]

const promises = numbers.map((number) => limiter(() => someFlakyFunction(number)))

// Some time passes, and all promises settle.
// Say the flaky function failed at 2, with the error "uh oh, [number]"

// This is what the promises array looks like then:
// [resolved, resolved, rejected('Error: uh oh, 2'), rejected('Error: uh oh, 2')]
```