### PR TITLE
Map

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,28 @@ Returns a function that can be used to wrap promise returning functions, limitin
 
 - `concurrency` the concurrency, i.e. 1 will limit calls to one at a time, effectively in sequence or serial. 2 will allow two at a time, etc. 0 or `undefined` specify no limit, and all calls will be run in parallel.
 
+limit
+=====
+
 ```js
-limit(fn: () => Promise<T>) => Promise<T>
+limit(fn: () -> Promise<T>) -> Promise<T>
 ```
 
 A function that limits calls to `fn`, based on `concurrency` above. Returns a promise that resolves or rejects the same value or error as `fn`. All functions are executed in the same order in which they were passed to `limit`. `fn` must return a promise.
 
-* `fn` a function that is called with no arguments and returns a promise. You can pass arguments to your function by putting it inside another function, i.e. `() => myfunc(a, b, c)`.
+* `fn` a function that is called with no arguments and returns a promise. You can pass arguments to your function by putting it inside another function, i.e. `() -> myfunc(a, b, c)`.
+
+limit.map
+=========
+
+```js
+limit.map(items: [T], mapper: (T) -> Promise<R>) -> Promise<[R]>
+```
+
+Maps an array of items using `mapper`, but limiting the number of concurrent calls to `mapper` with the `concurrency` of `limit`. If at least one call to `mapper` returns a rejected promise, the result of `map` is a the same rejected promise, and no further calls to `mapper` are made.
+
+limit.queue
+===========
 
 ```js
 limit.queue: Number

--- a/index.js
+++ b/index.js
@@ -63,5 +63,24 @@ module.exports = function (count) {
 
   semaphore.queue = 0
 
+  semaphore.map = map
+
   return semaphore
+}
+
+function map (items, mapper) {
+  var failed = false
+
+  var limit = this
+
+  return Promise.all(items.map(function () {
+    return limit(() => {
+      if (!failed) {
+        return mapper.apply(undefined, arguments).catch(function (e) {
+          failed = true
+          throw e
+        })
+      }
+    })
+  }))
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {},
   "devDependencies": {
     "chai": "3.5.0",
+    "chai-as-promised": "5.3.0",
     "fs-promise": "0.5.0",
     "lowscore": "1.8.0",
     "mocha": "2.4.5",


### PR DESCRIPTION
```js
limit.map(items: [T], mapper: (T) -> Promise<R>) -> Promise<[R]>
```

Maps an array of items using `mapper`, but limiting the number of concurrent calls to `mapper` with the `concurrency` of `limit`. If at least one call to `mapper` returns a rejected promise, the result of `map` is a the same rejected promise, and no further calls to `mapper` are made.
