### PR TITLE
Fix "Maximum call stack size exceeded" error for some failure cases

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,13 +34,7 @@ module.exports = function (count) {
   function run (fn) {
     outstanding++
     try {
-      var result = fn()
-
-      if (!result || typeof result.then !== 'function') {
-        throw new Error('expected function to return a promise')
-      }
-
-      return result.then(function (result) {
+      return Promise.resolve(fn()).then(function (result) {
         remove()
         return result
       }, function (error) {


### PR DESCRIPTION
**DO NOT MERGE, this is an issue that needs some discussion**

---

Okay so this is a tricky problem with promise-limit, and this is why:

If run() throws an error, [its handler](https://github.com/SEAPUNK/promise-limit/blob/3103a09294380bbb3b6af92dee177e7015d3ff9a/index.js#L50-L52) synchronously calls remove(), which in turn calls run() for the next function, and this behavior could repeat if the next item in the queue is going to cause the error handler to execute, etc., causing a "Maximum call stack size exceeded" error.

There are actually a few ways to fix this, and they all have their downsides:

1: Avoid the ["expected function to return a promise"](https://github.com/SEAPUNK/promise-limit/blob/3103a09294380bbb3b6af92dee177e7015d3ff9a/index.js#L40) error by returning a Promise for the rest of the items at `.map()`.

This *partially* solves the issue, but will still cause problems in general, if people use a large array, still manage to call the handler, by either not returning a Promise, or otherwise.

2: Allow non-promise return values of functions, by replacing [this](https://github.com/SEAPUNK/promise-limit/blob/3103a09294380bbb3b6af92dee177e7015d3ff9a/index.js#L37-L43) with below:

```js
return Promise.resolve(fn()).then(function (result) {
// ...
```

This _partially, but more completely_ solves the issue, and will not require any changes to `.map()`, as `undefined` (the returned value on map cancel) will just be passed to `.then()` as `result`. An added benefit is that this will no longer require the limiter function to return a Promise. However, if the mapping function (`fn`, the part that's supposed to return a Promise) throws an error, and if all the remaining calls to the mapping function are going to throw an error, and there are enough calls to the mapping function, then it's going to cause the same error:

```js
const limiter = promiseLimit(100)
await limiter.map(largeArray, i => {
  return processItem(i.data) // uh oh, the rest of the items are undefined,
                             // so accessing the data property throws an error
                             // for the rest of the calls to this function
})
```

3: Forcing the call to `remove()` to be asynchronous, by making its call to `dequeue()` be wrapped in setImmediate, or setTimeout if setImmediate is not available.

The benefit is that that will be the only change that will be necessary, and it will handle all cases.

The downside is that the limiter will run slower, and potentially _significantly_ slower, if we cannot use setImmediate, and have to use setTimeout instead.
That, and we'll probably have to use an external module `set-immediate-shim`, to correctly choose the function that gets called for us.

---

I'm leaning towards using ~~No. 2~~ No. 3, _as well as_ No. 2 (as a feature/breaking change) (considering how the performance impact, regardless of setImmediate or setTimeout, shouldn't really be that big of a problem) as the solution, but it's your call.

---

- [ ] TODO: commit that actually chooses the solution
- [ ] TODO: test for the fix
