### PR TITLE
Fix the map function's type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,7 +22,7 @@ declare interface limitInterface<T> {
    * @param items any items
    * @param mapper iterator
    */
-  map(items: [T], mapper: (T) => Promise<T>): Promise<[T]>
+  map(items: T[], mapper: (T) => Promise<T>): Promise<[T]>
 
   /**
    * Returns the queue length, the number of jobs that are waiting to be started.


### PR DESCRIPTION
`[T]` represents a tuple of size one, `T[]` represents an array of arbitrary size.

So, if `T = string`, then `["foo"]` is valid for `[T]`, but `["foo", "bar"]` is not.