### PR TITLE
Update index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,7 +22,7 @@ declare interface limitInterface<T> {
    * @param items any items
    * @param mapper iterator
    */
-  map(items: [T], mapper: (T) => Promise<T>): Promise<[T]>
+  map<U>(items: ReadonlyArray<T>, mapper: (value: T) => Promise<U>): Promise<U[]>
 
   /**
    * Returns the queue length, the number of jobs that are waiting to be started.


### PR DESCRIPTION
`limitInterface<T>.map`:
* Change `items` to be a readonly array of `T` rather than a tuple of a single `T`.
* Give `mapper`'s argument a name, which is really changing it from `T: any` to `value: T`.
* A new generic argument has been introduced, `U`, which represents the eventual result of `mapper`.
* The return type has been fixed to eventually return an array of `U` rather than a tuple of a single `T`.